### PR TITLE
Improvements round

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Rules
   expected output.
 - If a piece of code raises an error, the captured output will be the 
   `#inspect` string of that exception.
+- If the first line of a code block includes the string `[:ignore_failure]`, 
+  the example will not be considered an error if it fails.
 
 To test the `README.md` in the current folder, just run:
 
@@ -85,10 +87,34 @@ puts 2 - 3
 ```
 
 ```ruby
-# This example should fail
+# This example may fail [:ignore_failure]
+# Due to the :ignore_failure flag, it will show the failure diff, but will
+# not be considered a failure in the exit status.
 puts 'hello world'.upcase
 #=> hello world
 ```
+
+```ruby
+# This example must fail [:must_fail]
+puts "this is a success"
+#=> this is a failure
+```
+
+```ruby
+# Code that does not generate any output will be executed before each
+# of the subsequent examples.
+def create_caption(text)
+  [text.upcase, ("=" * text.length)].join "\n"
+end
+```
+
+```ruby
+# Example that builds upon code that was defined earlier
+puts create_caption "tada!"
+#=> TADA!
+#=> =====
+```
+
 
 ### Shell
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Rules
 - If the first line of a code block includes the string `[:ignore_failure]`, 
   the example will not be considered an error if it fails.
 
+
 To test the `README.md` in the current folder, just run:
 
     $ docspec
@@ -92,12 +93,6 @@ puts 2 - 3
 # not be considered a failure in the exit status.
 puts 'hello world'.upcase
 #=> hello world
-```
-
-```ruby
-# This example must fail [:must_fail]
-puts "this is a success"
-#=> this is a failure
 ```
 
 ```ruby

--- a/bin/docspec
+++ b/bin/docspec
@@ -13,10 +13,6 @@ success = tester.execute
 
 say ''
 
-if tester.expected_failures != 0
-  say "!txtblu!Expected failures: #{tester.expected_failures}"
-end
-
 if success
   say "!txtgrn!#{tester.total} tests, #{tester.errors} failed\n"
   exit 0

--- a/lib/docspec/document.rb
+++ b/lib/docspec/document.rb
@@ -18,7 +18,7 @@ module Docspec
 
     def examples!
       result = []
-      markdown.scan(/```(ruby|shell)\n(.*?)```/m) do |type, code|
+      markdown.scan(/```(ruby|shell)\s*\n(.*?)```/m) do |type, code|
         result << Example.new(code, type)
       end
       result

--- a/lib/docspec/example.rb
+++ b/lib/docspec/example.rb
@@ -42,10 +42,6 @@ module Docspec
       @label ||= label!
     end
 
-    def must_fail?
-      flags.include? :must_fail
-    end
-
     def prepend(codes)
       codes = [codes] unless codes.is_a? Array
       codes = codes.join "\n\n"
@@ -53,7 +49,7 @@ module Docspec
     end
 
     def success?
-      must_fail? ? actual != expected : actual == expected
+      actual == expected
     end
 
   protected

--- a/lib/docspec/example.rb
+++ b/lib/docspec/example.rb
@@ -60,7 +60,7 @@ module Docspec
         when 'ruby'
           eval full_code
         when 'shell'
-          puts `#{full_code}`
+          puts `#{code}`
         end
       end.strip
     end

--- a/lib/docspec/example.rb
+++ b/lib/docspec/example.rb
@@ -3,49 +3,74 @@ require 'diffy'
 module Docspec
   class Example
     include OutputCapturer
-
-    attr_reader :code, :type
+    attr_reader :code, :type, :full_code
 
     def initialize(code, type)
       @code, @type = code, type
-    end
-
-    def label
-      @label ||= label!
-    end
-
-    def expected
-      @expected ||= code.scan(/#=>\s*(.*)/).map { |match| match.first.strip }.join "\n"
+      @full_code = @code
     end
 
     def actual
       @actual ||= actual!
     end
 
-    def passing?
-      actual == expected
+    def diff
+      @diff ||= Diffy::Diff.new("#{expected}\n", "#{actual}\n", context: 2).to_s :color
     end
 
-    def diff
-      Diffy::Diff.new(expected, actual, context: 2).to_s :color
+    def empty?
+      actual.empty?
+    end
+
+    def expected
+      @expected ||= code.scan(/#=>\s*(.*)/).map { |match| match.first.strip }.join "\n"
+    end
+
+    def first_line
+      @first_line ||= code.split("\n").first
+    end
+
+    def flags
+      @flags ||= first_line.scan(/\[:(.+?)\]/).map { |f| f.first.to_sym }
+    end
+
+    def ignore_failure?
+      flags.include? :ignore_failure
+    end
+
+    def label
+      @label ||= label!
+    end
+
+    def must_fail?
+      flags.include? :must_fail
+    end
+
+    def prepend(codes)
+      codes = [codes] unless codes.is_a? Array
+      codes = codes.join "\n\n"
+      @full_code = "#{codes}\n#{@full_code}"
+    end
+
+    def success?
+      must_fail? ? actual != expected : actual == expected
     end
 
   protected
-
-    def label!
-      first_line = code.split("\n").first
-      first_line.gsub(/^#\s*/, '').strip
-    end
 
     def actual!
       capture_output do
         case type
         when 'ruby'
-          instance_eval(code)
+          eval full_code
         when 'shell'
-          puts `#{code}`
+          puts `#{full_code}`
         end
       end.strip
+    end
+
+    def label!
+      first_line.gsub(/^#\s*/, '').strip
     end
 
   end


### PR DESCRIPTION
- [x] Marking an example with `[:ignore_failure]` will allow it to fail
- [x] Examples that do not generate any output will be prepended to all the subsequent examples.